### PR TITLE
Variable access via 'realmstring' is deprecated. Use '@realmstring'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ coverage/
 .tmp/
 .librarian/
 
+.rubocop.yml
+Vagrantfile
+.vagrant/

--- a/spec/defines/config/sslcert_spec.rb
+++ b/spec/defines/config/sslcert_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'svn::config::credentials' do
+describe 'svn::config::sslcert' do
   uuid = 'd3c8a345b14f6a1b42251aef8027ab57'
   user = 'user'
 
@@ -12,17 +12,14 @@ describe 'svn::config::credentials' do
   let(:title) { uuid }
   let(:params) {{
     :realmstring => '<https://svn.example.com:443> Committers',
-    :username => 'brett',
-    :password => 'PaSsWoRd',
+    :value => 'my_cert_value',
   }}
-  it "should create the simple auth credentials" do
-    file = "/home/user/.subversion/auth/svn.simple/#{uuid}"
+  it "should create the ssl cert cache" do
+    file = "/home/user/.subversion/auth/svn.ssl.server/#{uuid}"
     should contain_file(file).with_owner(user)
       .with_content(%r[V 40])
       .with_content(%r[<https://svn.example.com:443> Committers])
-      .with_content(%r[V 5])
-      .with_content(%r[brett])
-      .with_content(%r[V 8])
-      .with_content(%r[PaSsWoRd])
+      .with_content(%r[V 13])
+      .with_content(%r[my_cert_value])
   end
 end

--- a/templates/simpleauth.erb
+++ b/templates/simpleauth.erb
@@ -4,14 +4,14 @@ V 6
 simple
 K 8
 password
-V <%= password.length %>
-<%= password %>
+V <%= @password.length %>
+<%= @password %>
 K 15
 svn:realmstring
-V <%= realmstring.length %>
-<%= realmstring %>
+V <%= @realmstring.length %>
+<%= @realmstring %>
 K 8
 username
-V <%= username.length %>
-<%= username %>
+V <%= @username.length %>
+<%= @username %>
 END

--- a/templates/sslserver.erb
+++ b/templates/sslserver.erb
@@ -1,13 +1,13 @@
 K 10
 ascii_cert
-V <%= value.length %>
-<%= value %>
+V <%= @value.length %>
+<%= @value %>
 K 8
 failures
 V 1
 8
 K 15
 svn:realmstring
-V <%= realmstring.length %>
-<%= realmstring %>
+V <%= @realmstring.length %>
+<%= @realmstring %>
 END


### PR DESCRIPTION
In Puppet 4 this breaks completely. Also I added tests for the sslcert
template.
